### PR TITLE
fix(parser): plural form may be multiline

### DIFF
--- a/po.js
+++ b/po.js
@@ -466,6 +466,7 @@ define([
         startFromInlinedText = startFromInlinedText.substr(0, nextSemicolon);
         startFromInlinedText = startFromInlinedText.replace('plural=', '');
         startFromInlinedText = startFromInlinedText.replace(/'/g, '"');
+        startFromInlinedText = startFromInlinedText.replace(/"\n"/g, ' ');
 
         if (options.useDefine) {
             localeFunc = 'define(function defineInternationalization_' + globalConfig.locale + '_Locale () {\n' +


### PR DESCRIPTION
e.g.

```
"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<="
"4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
```