### PR TITLE
add option useMessageformatPlurals

### DIFF
--- a/example/main.js
+++ b/example/main.js
@@ -8,7 +8,7 @@ require.config({
     },
     po: {
       // avoid loading the locale.js
-      usePluralFromPo: true,
+      useMessageformatPlurals: true,
       i18nLocation: 'i18n'
     }
 });


### PR DESCRIPTION
By using the option `useMessageformatPlurals: true` both the runtime and the build paths completely ignore the locale.js and "Plural-Forms" header. However, the build still doesn't work with MessageFormat@1.0.2 so sticking to 0.3.1 for now.